### PR TITLE
integrate with racket-langserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 out/
 .DS_Store
 node_modules
+out/
+.vscode-test/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 out/
 .DS_Store
 node_modules
-out/
-.vscode-test/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "racket-langserver"]
+	path = racket-langserver
+	url = https://github.com/JJPro/racket-langserver.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-racket",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -86,8 +86,7 @@
     "@types/vscode": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
-      "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
-      "dev": true
+      "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.29.0",
@@ -2304,6 +2303,41 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vscode-jsonrpc": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+    },
+    "vscode-languageclient": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.3.tgz",
+      "integrity": "sha512-YciJxk08iU5LmWu7j5dUt9/1OLjokKET6rME3cI4BRpiF6HZlusm2ZwPt0MYJ0lV5y43sZsQHhyon2xBg4ZJVA==",
+      "requires": {
+        "semver": "^6.3.0",
+        "vscode-languageserver-protocol": "^3.15.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+      "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+      "requires": {
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-types": "3.15.1"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
     },
     "vscode-test": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "magic-racket",
   "displayName": "Magic Racket",
   "description": "Language support for Racket: top notch syntax highlighting and REPL integration.",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "activationEvents": [
     "onCommand:magic-racket.loadFileIntoNewRepl",
     "onCommand:magic-racket.loadFileIntoRepl",
     "onCommand:magic-racket.runFile",
     "onCommand:magic-racket.executeSelectionInRepl",
-    "onCommand:magic-racket.openRepl"
+    "onCommand:magic-racket.openRepl",
+    "onLanguage:racket"
   ],
   "main": "./out/extension.js",
   "galleryBanner": {
@@ -182,6 +183,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
-    "@types/vscode": "^1.39.0"
+    "@types/vscode": "^1.39.0",
+    "vscode-languageclient": "^6.1.3"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,7 +91,8 @@ export function activate(context: vscode.ExtensionContext) {
 	const executable = {
 		command: 'racket',
     // args: ['--lib', 'racket-langserver'],
-    args: [context.asAbsolutePath('racket-langserver/main.rkt')],
+    // args: [context.asAbsolutePath('racket-langserver/main.rkt')],
+    args: [context.asAbsolutePath('racket-language-server/main.rkt')],
 	};
 
 	// If the extension is launched in debug mode then the debug server options are used

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,8 +91,8 @@ export function activate(context: vscode.ExtensionContext) {
 	const executable = {
 		command: 'racket',
     // args: ['--lib', 'racket-langserver'],
-    // args: [context.asAbsolutePath('racket-langserver/main.rkt')],
-    args: [context.asAbsolutePath('racket-language-server/main.rkt')],
+    args: [context.asAbsolutePath('racket-langserver/main.rkt')],
+    // args: [context.asAbsolutePath('racket-language-server/main.rkt')],
 	};
 
 	// If the extension is launched in debug mode then the debug server options are used

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { LanguageClient } from 'vscode-languageclient';
+import { LanguageClient } from "vscode-languageclient";
 
 let langClient: LanguageClient;
 
@@ -81,52 +81,51 @@ function loadFileInRepl(repl: vscode.Terminal, filePath: string) {
 
 export function deactivate() {
   if (!langClient) {
-		return undefined;
-	}
-	return langClient.stop();
+    return undefined;
+  }
+  return langClient.stop();
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  //******* Language Client ********
-	const executable = {
-		command: 'racket',
+  /* ****** Language Client ******* */
+  const executable = {
+    command: "racket",
     // args: ['--lib', 'racket-langserver'],
-    args: [context.asAbsolutePath('racket-langserver/main.rkt')],
+    args: [context.asAbsolutePath("racket-langserver/main.rkt")],
     // args: [context.asAbsolutePath('racket-language-server/main.rkt')],
-	};
+  };
 
-	// If the extension is launched in debug mode then the debug server options are used
-	// Otherwise the run options are used
-	let serverOptions = {
-		run: executable,
-		debug: executable
-	};
+  // If the extension is launched in debug mode then the debug server options are used
+  // Otherwise the run options are used
+  const serverOptions = {
+    run: executable,
+    debug: executable,
+  };
 
-	// Options to control the language client
-	let clientOptions = {
-		// Register the server for racket documents
-		documentSelector: [{ scheme: 'file', language: 'racket' }],
-		synchronize: {
-			// Notify the server about file changes to '.clientrc files contained in the workspace
-			fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
-		}
-	};
+  // Options to control the language client
+  const clientOptions = {
+    // Register the server for racket documents
+    documentSelector: [{ scheme: "file", language: "racket" }],
+    synchronize: {
+      // Notify the server about file changes to '.clientrc files contained in the workspace
+      fileEvents: vscode.workspace.createFileSystemWatcher("**/.clientrc"),
+    },
+  };
 
-	// Create the language client and start the client.
-	langClient = new LanguageClient(
-		'magic-racket',
-		'Racket Language Client',
-		serverOptions,
-		clientOptions
-	);
+  // Create the language client and start the client.
+  langClient = new LanguageClient(
+    "magic-racket",
+    "Racket Language Client",
+    serverOptions,
+    clientOptions,
+  );
 
-	// Start the client. This will also launch the server
-	langClient.start();
+  // Start the client. This will also launch the server
+  langClient.start();
 
-  //******* Language Client END ********
+  /* ****** Language Client END ******* */
 
-
-  let loadFileIntoCurrent = vscode.commands.registerCommand(
+  const loadFileIntoCurrent = vscode.commands.registerCommand(
     "magic-racket.loadFileIntoRepl",
     () => {
       const editor = vscode.window.activeTextEditor;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,8 @@ export function activate(context: vscode.ExtensionContext) {
   //******* Language Client ********
 	const executable = {
 		command: 'racket',
-		args: ['--lib', 'racket-langserver'],
+    // args: ['--lib', 'racket-langserver'],
+    args: [context.asAbsolutePath('racket-langserver/main.rkt')],
 	};
 
 	// If the extension is launched in debug mode then the debug server options are used


### PR DESCRIPTION
Resolves #7 
Add Racket Language Client support.

Integrates with racket-langserver, which is required to be installed via: 
```sh 
raco pkg install racket-langserver
```
This requires this [PR](https://github.com/jeapostrophe/racket-langserver/pull/11) to work perfectly. 
Until that PR got merged, we could have my local modified copy included in our project like now. 
🎉🎉🎉

#### One place could be improved: 
auto check and install `racket-langserver` if not installed. 
Maybe you can help with this. 

------

![output3](https://user-images.githubusercontent.com/871037/78971266-2b3aff00-7ad9-11ea-81ee-843fac7a3fd2.gif)



