### PR TITLE
[Enhancement] Clear terminal output before a new run

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -21,6 +21,7 @@ export function executeSelectionInRepl(repl: vscode.Terminal, editor: vscode.Tex
 
 export function runFileInTerminal(racket: string, filePath: string, terminal: vscode.Terminal) {
   terminal.show();
+  terminal.sendText(`clear`);
   const shell: string | undefined = vscode.workspace
     .getConfiguration("terminal.integrated.shell")
     .get("windows");


### PR DESCRIPTION
Just an enhancement from my point of view. 
I didn't want to scroll to see the latest output of the compilation process.