### PR TITLE
Change keybinding for lambda snippet to Option+\

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ You can set the names of the REPLs and output terminals in the settings.
 
 These aren't game-changers, but they certainly help.
 
-- You can write a λ (lambda) by using the included snippet `lmb` or the shortcut <kbd>Cmd+/</kbd> (or <kbd>Ctrl+/</kbd> on Windows and Linux)
-  - If anybody knows how to bind it to <kbd>Cmd+\\</kbd>, let me know
+- You can write a λ (lambda) by using the included snippet `lmb` or the shortcut <kbd>Cmd+\\</kbd> (or <kbd>Ctrl+\\</kbd> on Windows and Linux)
 - VS Code recognizes the "words" in Racket correctly, meaning that moving among words using <kbd>Ctrl+Left</kbd> and <kbd>Ctrl+Right</kbd> works as expected, and so does the double-click word selection
 
 ## Release notes

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can set the names of the REPLs and output terminals in the settings.
 
 These aren't game-changers, but they certainly help.
 
-- You can write a λ (lambda) by using the included snippet `lmb` or the shortcut <kbd>Cmd+\\</kbd> (or <kbd>Ctrl+\\</kbd> on Windows and Linux)
+- You can write a λ (lambda) by using the included snippet `lmb` or the shortcut <kbd>Option+\\</kbd> (or <kbd>Alt+\\</kbd> on Windows and Linux)
 - VS Code recognizes the "words" in Racket correctly, meaning that moving among words using <kbd>Ctrl+Left</kbd> and <kbd>Ctrl+Right</kbd> works as expected, and so does the double-click word selection
 
 ## Release notes

--- a/package.json
+++ b/package.json
@@ -179,8 +179,8 @@
         "when": "resourceLangId == racket && editorHasSelection"
       },
       {
-        "key": "Ctrl+\\",
-        "mac": "Cmd+\\",
+        "key": "Alt+\\",
+        "mac": "Alt+\\",
         "command": "editor.action.insertSnippet",
         "when": "resourceLangId == racket && editorTextFocus",
         "args": {

--- a/package.json
+++ b/package.json
@@ -179,8 +179,8 @@
         "when": "resourceLangId == racket && editorHasSelection"
       },
       {
-        "key": "Ctrl+/",
-        "mac": "Cmd+/",
+        "key": "Ctrl+\\",
+        "mac": "Cmd+\\",
         "command": "editor.action.insertSnippet",
         "when": "resourceLangId == racket && editorTextFocus",
         "args": {


### PR DESCRIPTION
This changes the keybinding for the lambda snippet from <kbd>Cmd+/</kbd> to <kbd>Cmd+\\</kbd> on Mac, and from <kbd>Ctrl+/</kbd> to <kbd>Ctrl+\\</kbd> on Windows/Linux. This was mentioned in the README as a possible change, and <kbd>Cmd+/</kbd> usually toggles commenting on the selected text, so this change is further warranted to restore that functionality. 