### PR TITLE
Add configuration option to disable LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This extension adds support for [Racket](http://www.racket-lang.org) to VS Code.
     raco pkg update racket-langserver
     ```
 
+    If don't want to use the lang-server at all, you don't have to. Just set `"magic-racket.lsp.enabled": false` in your configuration file. But note that if you do so, you won't get the “smart” features like autocomplete, formatting, etc.
+
 ## Features
 
 Magic Racket **does**
@@ -83,7 +85,7 @@ These aren't game-changers, but they certainly help.
 
 ## Configuration
 
-Magic Racket's options can be found in the `Magic Racket` section in VSCode preferences. 
+Magic Racket's options can be found in the `Magic Racket` section in VSCode preferences.
 
 However, if you would like to change some VSCode option _only_ for Racket (e.g. if you don't like the predefined editor rulers), you can do so by directly adding them into a `[racket]` section in `settings.json`:
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
           "type": "string",
           "default": "REPL ($name)",
           "markdownDescription": "Specifies the template string for the title of racket REPLs. Substring `$name` will get replaced by the file name."
+        },
+        "magic-racket.lsp.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enables language server support"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,13 @@ function reg(name: string, func: (...args: any[]) => any) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  setupLSP();
+  const enableLSP: boolean = vscode.workspace
+    .getConfiguration("magic-racket.lsp")
+    .get("enabled", true);
+
+  if (enableLSP) {
+    setupLSP();
+  }
 
   // Each file has one output terminal and one repl
   // Those two are saved in terminals and repls, respectively

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as com from "./commands";
 import { withRacket } from "./utils";
 
 let langClient: LanguageClient;
+let isLangClientRunning: boolean = false;
 
 export function deactivate() {
   if (!langClient) {
@@ -48,9 +49,6 @@ function setupLSP() {
       serverOptions,
       clientOptions,
     );
-
-    // Start the client. This will also launch the server
-    langClient.start();
   });
 }
 
@@ -58,20 +56,33 @@ function reg(name: string, func: (...args: any[]) => any) {
   return vscode.commands.registerCommand(`magic-racket.${name}`, func);
 }
 
-export function activate(context: vscode.ExtensionContext) {
+function configurationChanged() {
   const enableLSP: boolean = vscode.workspace
     .getConfiguration("magic-racket.lsp")
     .get("enabled", true);
 
-  if (enableLSP) {
-    setupLSP();
+  if (langClient) {
+    if (enableLSP && !isLangClientRunning) {
+      langClient.start();
+      isLangClientRunning = true;
+    } else {
+      langClient.stop();
+      isLangClientRunning = false;
+    }
   }
+}
+
+export function activate(context: vscode.ExtensionContext) {
+  setupLSP();
+  configurationChanged();
 
   // Each file has one output terminal and one repl
   // Those two are saved in terminals and repls, respectively
   // The file is _ran_ in the terminal and _loaded_ into a repl
   const terminals: Map<string, vscode.Terminal> = new Map();
   const repls: Map<string, vscode.Terminal> = new Map();
+
+  vscode.workspace.onDidChangeConfiguration(configurationChanged);
 
   vscode.window.onDidCloseTerminal((terminal) => {
     terminals.forEach((val, key) => val === terminal && terminals.delete(key) && val.dispose());


### PR DESCRIPTION
This solves #32 

I've never worked with VS Code extension so hopefully it's implemented correctly. But it behaves correctly.

It simply subscribes a callback to `onDidChangeConfiguration` event which reads value of `magic-racket.lsp.enabled` configuration and starts/stops language client accordingly.