### PR TITLE
Save active file on repl run

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,10 +18,14 @@ function getOrDefault<K, V>(map: Map<K, V>, key: K, getDefault: () => V): V {
   return def;
 }
 
+function saveActiveTextEditorAndRun(f: () => void) {
+  vscode.window.activeTextEditor?.document?.save().then(() => f());
+}
+
 export function runInTerminal(terminals: Map<string, vscode.Terminal>): void {
   withFilePath((filePath: string) => {
     withRacket((racket: string) => {
-      let terminal;
+      let terminal: vscode.Terminal;
       if (
         vscode.workspace
           .getConfiguration("magic-racket.outputTerminal")
@@ -31,7 +35,7 @@ export function runInTerminal(terminals: Map<string, vscode.Terminal>): void {
       } else {
         terminal = getOrDefault(terminals, filePath, () => createTerminal(filePath));
       }
-      runFileInTerminal(racket, filePath, terminal);
+      saveActiveTextEditorAndRun(() => runFileInTerminal(racket, filePath, terminal));
     });
   });
 }
@@ -40,7 +44,7 @@ export function loadInRepl(repls: Map<string, vscode.Terminal>): void {
   withFilePath((filePath: string) => {
     withRacket((racket: string) => {
       const repl = getOrDefault(repls, filePath, () => createRepl(filePath, racket));
-      loadFileInRepl(filePath, repl);
+      saveActiveTextEditorAndRun(() => loadFileInRepl(filePath, repl));
     });
   });
 }


### PR DESCRIPTION
I probably should post it as separate PRs, but all these "features" are too questionable to me
I) Save a file when user presses "Run file in terminal" or "Load file in REPL"
Why? Merely for consistency. "Execute selection in REPL" works with a current "visible" selection, while aforementioned options work with some "background" text (if text was edited). Here is simple example of that
![ut39SOP7ix](https://user-images.githubusercontent.com/8329446/120513030-0c42af00-c3f6-11eb-8503-f85b8d5271b9.gif)
Yes, I am aware of "File/Auto Save", but that actually makes it even worse as due to "save delay" sometimes it saves file before i press "run", and sometimes it doesn't

II) and here is my favourite hackiest solution of all time. As described in corresponding issue (#40) REPL simply ignores passed commands if it wasn't already working. I presume we need to wait some time for Racket REPL to actually start. On my PC it takes about 450-550 ms. So the best I could do is to use setTimeout to wait for 1 second 😺 . Well, at least it doesn't make things worse. The alternative would be to pass code to Racket on start with something like "racket -i -e (...)", but I presume this is impossible to do correctly in crossplatform manner in cmd/terminal. If only there was a way to ask racket repl whether it's fully launched or not...
