### PR TITLE
Don't use 'shell-quote' on Windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,25 @@
 import * as vscode from "vscode";
 
+export const isWindowsOS: () => boolean = () => process.platform === "win32";
+export const isCmdExeShell: () => boolean = () => vscode.env.shell.endsWith("cmd.exe");
+export const isPowershellShell: () => boolean =
+  () => ["powershell.exe", "pwsh.exe", "pwsh"].some(p => vscode.env.shell.endsWith(p));
+
+export function quoteWindowsPath(path: string, isRacketExe: boolean): string {
+  if (/\s/.test(path)) { // quote the path only if it contains whitespaces
+    if (isCmdExeShell()) {
+      path = `"${path}"`;
+    } else if (isPowershellShell() && isRacketExe) {
+      path = `& '${path}'`;
+    } else {
+      path = `'${path}'`;
+    }
+  }
+  return path;
+}
+
 function normalizeFilePath(filePath: string): string {
-  if (process.platform === "win32") {
+  if (isWindowsOS()) {
     return filePath.replace(/\\/g, "/");
   }
   return filePath;


### PR DESCRIPTION
Fixes #63

shell-quote is completely incompatible with Windows
1) Paths may contain colons, but shell-quote escapes them (`C:/example.rkt` => `C\:/example.rkt`)
2) If executable path is quoted in Powershell, it should be prepended by `&` to run. i.e. to launch Racket from the full path in Powershell one should type something like  `& 'C:\Program Files\Racket\Racket.exe' example.rkt`

I have tested this in Command Prompt (cmd.exe), Powershell (powershell.exe) and Git Bash