### PR TITLE
Fix various comment syntax highlighting cases

### DIFF
--- a/syntaxes/racket.tmLanguage.json
+++ b/syntaxes/racket.tmLanguage.json
@@ -355,6 +355,9 @@
           "include": "#dot"
         },
         {
+          "include": "#comment"
+        },
+        {
           "include": "#args"
         }
       ]
@@ -505,6 +508,9 @@
           "include": "#keyword"
         },
         {
+          "include": "#comment"
+        },
+        {
           "include": "#default-args"
         },
         {
@@ -652,6 +658,9 @@
             }
           },
           "patterns": [
+            {
+              "include": "#comment"
+            },
             {
               "include": "#default-args-struct"
             },
@@ -1051,6 +1060,9 @@
     },
     "hash-content": {
       "patterns": [
+        {
+          "include": "#comment"
+        },
         {
           "include": "#pairing"
         }

--- a/syntaxes/src/racket.yaml
+++ b/syntaxes/src/racket.yaml
@@ -231,6 +231,7 @@ repository:
     patterns:
       - include: '#function-name'
       - include: '#dot'
+      - include: '#comment'
       - include: '#args'
 
   function-name:
@@ -332,6 +333,7 @@ repository:
   args:
     patterns:
       - include: '#keyword'
+      - include: '#comment'
       - include: '#default-args'
       - name: variable.parameter.racket
         match: "[^(\\#)\\[\\]{}\",'`;\\s][^()\\[\\]{}\",'`;\\s]*"
@@ -423,6 +425,7 @@ repository:
           '0':
             name: punctuation.section.fields.end.racket
         patterns:
+          - include: '#comment'
           - include: '#default-args-struct'
           - include: '#struct-field'
       - name: meta.struct.fields.racket
@@ -655,6 +658,7 @@ repository:
 
   hash-content:
     patterns:
+      - include: '#comment'
       - include: '#pairing'
 
   pairing:


### PR DESCRIPTION
This fixes several comment syntax highlighting cases, including comments in:

* struct fields
* hash literal content
* function arguments

<img width="197" alt="image" src="https://user-images.githubusercontent.com/279572/196816338-985e0439-39ec-43a6-b76f-2fbe79df6776.png">

<img width="216" alt="image" src="https://user-images.githubusercontent.com/279572/196816395-3a7e3430-6b6b-457a-a71f-1e2403a0686f.png">

<img width="272" alt="image" src="https://user-images.githubusercontent.com/279572/196816440-64263360-eb22-400d-8cf3-fce15b385086.png">

<img width="241" alt="image" src="https://user-images.githubusercontent.com/279572/196816472-f4f1318f-2443-4590-a8f4-9de32df590e6.png">

Fixes https://github.com/Eugleo/magic-racket/issues/71