### PR TITLE
Provide an icon for the language

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
         "extensions": [
           ".rkt"
         ],
+        "icon": {
+          "light": "images/icon.png",
+          "dark": "images/icon.png"
+        },
         "configuration": "language-configuration.json"
       }
     ],


### PR DESCRIPTION
Thanks for making this extension!

I noticed that currently there is no icon for Racket files in the Explorer or in open tabs. This PR provides an icon for those places using the same `images/icon.png` that the extension itself uses.