### PR TITLE
Fix character brackets behave like normal code

### DIFF
--- a/syntaxes/racket.tmLanguage.json
+++ b/syntaxes/racket.tmLanguage.json
@@ -1474,7 +1474,7 @@
     "character": {
       "patterns": [
         {
-          "name": "constant.character.racket",
+          "name": "string.quoted.single.racket",
           "match": "(?x) \\#\\\\\n  (?:\n    (?: [0-7]{3}) |\n    (?: u[0-9a-fA-F]{1,4}) |\n    (?: U[0-9a-fA-F]{1,6}) |\n    (?:\n      (?:\n        null? | newline | linefeed | backspace | vtab | page |\n        return | space | rubout | (?: [^\\w\\s] | \\d)\n      )\n      (?![a-zA-Z])\n    ) |\n    (?: [^\\W\\d](?=[\\W\\d]) | \\W )\n  )\n"
         }
       ]

--- a/syntaxes/src/racket.yaml
+++ b/syntaxes/src/racket.yaml
@@ -1155,7 +1155,7 @@ repository:
 
   character:
     patterns:
-      - name: constant.character.racket
+      - name: string.quoted.single.racket
         match: |
           (?x) \#\\
             (?:


### PR DESCRIPTION
Fixes #80.

Original code misunderstood schematic differences between "constant.character.racket" and "string.quoted.single.racket":

- `string.quoted.single.*` usually means `'sometext'` form
- `string.quoted.double.*` usually means `"sometext"` form
- `constant.character.*`   usually represents `"\someescaped"` highlighting form

In this specific context `#\char` falls into the first category.