### PR TITLE
Update README to mention Rhombus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Magic Racket **does**
 - Support Racket LSP through [racket-langserver](https://github.com/jeapostrophe/racket-langserver), which brings jump to definition, hover information, formatting, and more
 - Have nearly complete support for every valid Racket syntax: byte strings, regexps, define clauses, vectors... You name it, we have it
 - Support highlighting of all of the standard functions in `#lang racket`
+- ✅ New: Syntax highlighting and LSP support for Rhombus (.rhm) files
 - Turn many little VS Code knobs and switches to provide you the best possible Racket-writing experience
 
 ...but at the same time **doesn't**:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Magic Racket **does**
 - Support Racket LSP through [racket-langserver](https://github.com/jeapostrophe/racket-langserver), which brings jump to definition, hover information, formatting, and more
 - Have nearly complete support for every valid Racket syntax: byte strings, regexps, define clauses, vectors... You name it, we have it
 - Support highlighting of all of the standard functions in `#lang racket`
-- ✅ New: Syntax highlighting and LSP support for Rhombus (.rhm) files
+- Include syntax highlighting and LSP support for Rhombus (`.rhm`) files
 - Turn many little VS Code knobs and switches to provide you the best possible Racket-writing experience
 
 ...but at the same time **doesn't**:


### PR DESCRIPTION
fix to #140  

Added documentation for new Rhombus (`.rhm`) file support, including syntax highlighting and language server features, to the README. This makes the current extension capabilities clearer to users.