### PR TITLE
Add a command to open macro stepper for selected syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ This extension adds support for [Racket](http://www.racket-lang.org) to VS Code.
     ```
 
     If don't want to use the lang-server at all, you don't have to. Just set `"magicRacket.languageServer.enabled": false` in your configuration file. But note that if you do so, you won't get the “smart” features like autocomplete, formatting, etc.
-
 4. If you are running VSCode on WSL or a headless Linux server, please see the Troubleshooting section below.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@ This extension adds support for [Racket](http://www.racket-lang.org) to VS Code.
 2. Make sure you have `raco` on your path (see section Troubleshooting)
 3. Install the [racket-langserver](https://github.com/jeapostrophe/racket-langserver) by running the following command in the terminal:
 
-    ```bash
-    raco pkg install racket-langserver
-    ```
+   ```bash
+   raco pkg install racket-langserver
+   ```
 
-    Or update it using
+   Or update it using
 
-    ```bash
-    raco pkg update racket-langserver
-    ```
+   ```bash
+   raco pkg update racket-langserver
+   ```
 
-    If don't want to use the lang-server at all, you don't have to. Just set `"magicRacket.languageServer.enabled": false` in your configuration file. But note that if you do so, you won't get the “smart” features like autocomplete, formatting, etc.
+   If don't want to use the lang-server at all, you don't have to. Just set `"magicRacket.languageServer.enabled": false` in your configuration file. But note that if you do so, you won't get the “smart” features like autocomplete, formatting, etc.
+
 4. If you are running VSCode on WSL or a headless Linux server, please see the Troubleshooting section below.
 
 ## Features
@@ -77,6 +78,11 @@ The list of commands added by Magic Racket:
 - `Racket: Show the output terminal for the current file`
   - Similarly to the command above, this one shows the output terminal of the current file.
 
+### Macro Stepper
+
+- `Racket: Open macro stepper of line or selection as a syntax`
+  - For selected syntax, open a macro stepper for it. Available by using the shortcut <kbd>Alt+Shift+Enter</kbd>
+
 You can set the names of the REPLs and output terminals in the settings.
 
 ### Minor QoL features
@@ -134,15 +140,15 @@ However, after the installation, your computer doesn't _know_ where the command 
 - **(recommended)** add the directory where `raco` is located ([instructions for Unix](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix), and something like [this for PowerShell on Windows](https://stackoverflow.com/questions/714877/setting-windows-powershell-environment-variables))
 - first move to the directory where `raco` is located (by using `cd`, for example), and then run it by prefixing the `raco` command with `./` (Unix) or `.\` (Windows), like this:
 
-    ```bash
-    ./raco pkg update racket-langserver
-    ```
+  ```bash
+  ./raco pkg update racket-langserver
+  ```
 
-    or, on Windows,
+  or, on Windows,
 
-    ```bash
-    .\raco pkg update racket-langserver
-    ```
+  ```bash
+  .\raco pkg update racket-langserver
+  ```
 
 ## Release notes
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ This extension adds support for [Racket](http://www.racket-lang.org) to VS Code.
 2. Make sure you have `raco` on your path (see section Troubleshooting)
 3. Install the [racket-langserver](https://github.com/jeapostrophe/racket-langserver) by running the following command in the terminal:
 
-   ```bash
-   raco pkg install racket-langserver
-   ```
+    ```bash
+    raco pkg install racket-langserver
+    ```
 
-   Or update it using
+    Or update it using
 
-   ```bash
-   raco pkg update racket-langserver
-   ```
+    ```bash
+    raco pkg update racket-langserver
+    ```
 
-   If don't want to use the lang-server at all, you don't have to. Just set `"magicRacket.languageServer.enabled": false` in your configuration file. But note that if you do so, you won't get the “smart” features like autocomplete, formatting, etc.
+    If don't want to use the lang-server at all, you don't have to. Just set `"magicRacket.languageServer.enabled": false` in your configuration file. But note that if you do so, you won't get the “smart” features like autocomplete, formatting, etc.
 
 4. If you are running VSCode on WSL or a headless Linux server, please see the Troubleshooting section below.
 
@@ -140,15 +140,15 @@ However, after the installation, your computer doesn't _know_ where the command 
 - **(recommended)** add the directory where `raco` is located ([instructions for Unix](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix), and something like [this for PowerShell on Windows](https://stackoverflow.com/questions/714877/setting-windows-powershell-environment-variables))
 - first move to the directory where `raco` is located (by using `cd`, for example), and then run it by prefixing the `raco` command with `./` (Unix) or `.\` (Windows), like this:
 
-  ```bash
-  ./raco pkg update racket-langserver
-  ```
+    ```bash
+    ./raco pkg update racket-langserver
+    ```
 
-  or, on Windows,
+    or, on Windows,
 
-  ```bash
-  .\raco pkg update racket-langserver
-  ```
+    ```bash
+    .\raco pkg update racket-langserver
+    ```
 
 ## Release notes
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The list of commands added by Magic Racket:
 
 ### Macro Stepper
 
-- `Racket: Open macro stepper of line or selection as a syntax`
+- `Racket: Open line or selection in macro stepper`
   - For selected syntax, open a macro stepper for it. Available by using the shortcut <kbd>Alt+Shift+Enter</kbd>
 
 You can set the names of the REPLs and output terminals in the settings.

--- a/package.json
+++ b/package.json
@@ -206,8 +206,8 @@
         "title": "Racket: Execute line or selection in REPL"
       },
       {
-        "command": "magic-racket.expandMacroStepSelection",
-        "title": "Racket: Invoke the macro stepper of line or selection as a syntax"
+        "command": "magic-racket.openMacroStepper",
+        "title": "Racket: Open macro stepper of line or selection as a syntax"
       },
       {
         "command": "magic-racket.openRepl",
@@ -243,6 +243,11 @@
       {
         "command": "magic-racket.executeSelectionInRepl",
         "key": "Alt+Enter",
+        "when": "(resourceLangId == racket || resourceLangId == rhombus) && editorTextFocus"
+      },
+      {
+        "command": "magic-racket.openMacroStepper",
+        "key": "Alt+Shift+Enter",
         "when": "(resourceLangId == racket || resourceLangId == rhombus) && editorTextFocus"
       },
       {

--- a/package.json
+++ b/package.json
@@ -206,8 +206,8 @@
         "title": "Racket: Execute line or selection in REPL"
       },
       {
-        "command": "magic-racket.openMacroStepper",
-        "title": "Racket: Open macro stepper of line or selection as a syntax"
+        "command": "magic-racket.openSelectionInMacroStepper",
+        "title": "Racket: Open line or selection in macro stepper"
       },
       {
         "command": "magic-racket.openRepl",
@@ -246,7 +246,7 @@
         "when": "(resourceLangId == racket || resourceLangId == rhombus) && editorTextFocus"
       },
       {
-        "command": "magic-racket.openMacroStepper",
+        "command": "magic-racket.openSelectionInMacroStepper",
         "key": "Alt+Shift+Enter",
         "when": "(resourceLangId == racket || resourceLangId == rhombus) && editorTextFocus"
       },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
           "dark": "images/icon.png"
         },
         "configuration": "./language-configurations/racket.json"
-      },{
+      },
+      {
         "id": "rhombus",
         "aliases": [
           "Rhombus",
@@ -88,7 +89,7 @@
         "language": "racket",
         "scopeName": "source.racket",
         "path": "./syntaxes/racket.tmLanguage.json"
-      }, 
+      },
       {
         "language": "rhombus",
         "scopeName": "source.rhombus",
@@ -203,6 +204,10 @@
       {
         "command": "magic-racket.executeSelectionInRepl",
         "title": "Racket: Execute line or selection in REPL"
+      },
+      {
+        "command": "magic-racket.expandMacroStepSelection",
+        "title": "Racket: Invoke the macro stepper of line or selection as a syntax"
       },
       {
         "command": "magic-racket.openRepl",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,6 +5,7 @@ import {
   createRepl,
   loadFileInRepl,
   executeSelectionInRepl,
+  expandMacroStepSelectionInRepl,
 } from "./repl";
 import { withFilePath, withRacket, withEditor, withREPL } from "./utils";
 
@@ -61,6 +62,17 @@ export function executeSelection(repls: Map<string, vscode.Terminal>): void {
       withREPL((command: string[]) => {
         const repl = getOrDefault(repls, filePath, () => createRepl(filePath, command));
         executeSelectionInRepl(repl, editor);
+      });
+    });
+  });
+}
+
+export function expandMacroStepSelection(repls: Map<string, vscode.Terminal>): void {
+  withEditor((editor: vscode.TextEditor) => {
+    withFilePath((filePath: string) => {
+      withREPL((command: string[]) => {
+        const repl = getOrDefault(repls, filePath, () => createRepl(filePath, command));
+        expandMacroStepSelectionInRepl(repl, editor);
       });
     });
   });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,7 +5,7 @@ import {
   createRepl,
   loadFileInRepl,
   executeSelectionInRepl,
-  expandMacroStepSelectionInRepl,
+  openMacroStepperForSelection,
 } from "./repl";
 import { withFilePath, withRacket, withEditor, withREPL } from "./utils";
 
@@ -67,12 +67,12 @@ export function executeSelection(repls: Map<string, vscode.Terminal>): void {
   });
 }
 
-export function expandMacroStepSelection(repls: Map<string, vscode.Terminal>): void {
+export function openMacroStepper(repls: Map<string, vscode.Terminal>): void {
   withEditor((editor: vscode.TextEditor) => {
     withFilePath((filePath: string) => {
       withREPL((command: string[]) => {
         const repl = getOrDefault(repls, filePath, () => createRepl(filePath, command));
-        expandMacroStepSelectionInRepl(repl, editor);
+        openMacroStepperForSelection(repl, editor);
       });
     });
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,8 +115,18 @@ export function activate(context: vscode.ExtensionContext): void {
   const loadInRepl = reg("loadFileInRepl", () => com.loadInRepl(repls));
   const runInTerminal = reg("runFile", () => com.runInTerminal(terminals));
   const executeSelection = reg("executeSelectionInRepl", () => com.executeSelection(repls));
+  const expandMacroStepSelection = reg("expandMacroStepSelection", () =>
+    com.expandMacroStepSelection(repls),
+  );
   const openRepl = reg("openRepl", () => com.openRepl(repls));
   const showOutput = reg("showOutputTerminal", () => com.showOutput(terminals));
 
-  context.subscriptions.push(loadInRepl, runInTerminal, executeSelection, openRepl, showOutput);
+  context.subscriptions.push(
+    loadInRepl,
+    runInTerminal,
+    executeSelection,
+    expandMacroStepSelection,
+    openRepl,
+    showOutput,
+  );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,7 +115,9 @@ export function activate(context: vscode.ExtensionContext): void {
   const loadInRepl = reg("loadFileInRepl", () => com.loadInRepl(repls));
   const runInTerminal = reg("runFile", () => com.runInTerminal(terminals));
   const executeSelection = reg("executeSelectionInRepl", () => com.executeSelection(repls));
-  const expandMacroStepSelection = reg("openMacroStepper", () => com.openMacroStepper(repls));
+  const expandMacroStepSelection = reg("openSelectionInMacroStepper", () =>
+    com.openMacroStepper(repls),
+  );
   const openRepl = reg("openRepl", () => com.openRepl(repls));
   const showOutput = reg("showOutputTerminal", () => com.showOutput(terminals));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,9 +115,7 @@ export function activate(context: vscode.ExtensionContext): void {
   const loadInRepl = reg("loadFileInRepl", () => com.loadInRepl(repls));
   const runInTerminal = reg("runFile", () => com.runInTerminal(terminals));
   const executeSelection = reg("executeSelectionInRepl", () => com.executeSelection(repls));
-  const expandMacroStepSelection = reg("expandMacroStepSelection", () =>
-    com.expandMacroStepSelection(repls),
-  );
+  const expandMacroStepSelection = reg("openMacroStepper", () => com.openMacroStepper(repls));
   const openRepl = reg("openRepl", () => com.openRepl(repls));
   const showOutput = reg("showOutputTerminal", () => com.showOutput(terminals));
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -34,14 +34,13 @@ export function executeSelectionInRepl(repl: vscode.Terminal, editor: vscode.Tex
   editor.selections.forEach((sel) => send(editor.document.getText(sel)));
 }
 
-export function expandMacroStepSelectionInRepl(
+export function openMacroStepperForSelection(
   repl: vscode.Terminal,
   editor: vscode.TextEditor,
 ): void {
   const send = (s: string) => {
     const trimmed = s.trim();
     if (trimmed) {
-      repl.show(true);
       repl.sendText("(require macro-debugger/stepper)");
       repl.sendText(`(expand/step #'${trimmed})`);
     }
@@ -49,10 +48,8 @@ export function expandMacroStepSelectionInRepl(
 
   if (editor.selections.length === 1 && editor.selection.isEmpty) {
     send(editor.document.lineAt(editor.selection.active.line).text);
-    return;
   }
-
-  editor.selections.forEach((sel) => send(editor.document.getText(sel)));
+  // else we do nothing, don't jump out tons of macro steppers
 }
 
 export function runFileInTerminal(

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -42,6 +42,7 @@ export function expandMacroStepSelectionInRepl(
     const trimmed = s.trim();
     if (trimmed) {
       repl.show(true);
+      repl.sendText("(require macro-debugger/stepper)");
       repl.sendText(`(expand/step #'${trimmed})`);
     }
   };

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -34,6 +34,26 @@ export function executeSelectionInRepl(repl: vscode.Terminal, editor: vscode.Tex
   editor.selections.forEach((sel) => send(editor.document.getText(sel)));
 }
 
+export function expandMacroStepSelectionInRepl(
+  repl: vscode.Terminal,
+  editor: vscode.TextEditor,
+): void {
+  const send = (s: string) => {
+    const trimmed = s.trim();
+    if (trimmed) {
+      repl.show(true);
+      repl.sendText(`(expand/step #'${trimmed})`);
+    }
+  };
+
+  if (editor.selections.length === 1 && editor.selection.isEmpty) {
+    send(editor.document.lineAt(editor.selection.active.line).text);
+    return;
+  }
+
+  editor.selections.forEach((sel) => send(editor.document.getText(sel)));
+}
+
 export function runFileInTerminal(
   command: string[],
   filePath: string,


### PR DESCRIPTION
Add a command `magic-racket.openMacroStepper` which will send

```racket
(require macro-debugger/stepper)
;; and then
(expand/step #'syntax)
```

to REPL to execute (then this will open macro stepper GUI).

Also keybinding to `Alt+Shift+Enter`

This is originally a racket language server issue https://github.com/jeapostrophe/racket-langserver/issues/145, but I think magic racket can have this immediately by open Racket GUI.